### PR TITLE
pass IAM path to the uploader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+## 1.1.10
+- Fix bug where the IAM path was not being passed in to the uploader
+
 ## 1.1.9
 - Update requirements
 

--- a/cert_uploader/cli.py
+++ b/cert_uploader/cli.py
@@ -231,7 +231,10 @@ def main():
         }
 
         if options.type == 'iam':
-            upload_kwargs.update({'name': options.certificate_name})
+            upload_kwargs.update({
+                'name': options.certificate_name,
+                'iam_path': options.iam_path
+            })
 
         # Perform the upload
         arn = uploader.upload_certificate(**upload_kwargs)


### PR DESCRIPTION
Fixing bug where the IAM path was not passed to the `IAMCertificateUploader`